### PR TITLE
Handle tweaked keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ const handshake = new Noise(pattern, initiator, staticKeyPair, { curve })
 
 `DHLEN` = 32
 `PKLEN` = 32
+`SCALARLEN` = 32
 `SKLEN` = 64
 `ALG` = 'Ed25519'
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Generate a new keypair, optionally pass in a preexisting `privKey`. Return value
 ```
 {
   publicKey,
-  secretKey
+  secretKey,
 }
 ```
 
-#### `dh(pk, lsk)`
+#### `dh(publicKey, { secretKey, scalar })`
 
-Perform DH between `pk` and `lsk` and return the result.
+Perform DH between `publicKey` and `secretKey`/`scalar` and return the result.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const ALG = 'Ed25519'
 module.exports = {
   DHLEN,
   PKLEN,
+  SCALARLEN,
   SKLEN,
   ALG,
   name: ALG,

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const b4a = require('b4a')
 
 const DHLEN = sodium.crypto_scalarmult_ed25519_BYTES
 const PKLEN = sodium.crypto_scalarmult_ed25519_BYTES
+const SCALARLEN = sodium.crypto_scalarmult_ed25519_BYTES
 const SKLEN = sodium.crypto_sign_SECRETKEYBYTES
 const ALG = 'Ed25519'
 
@@ -38,23 +39,31 @@ function generateSeedKeyPair (seed) {
   return keyPair
 }
 
-function dh (pk, lsk) {
-  assert(lsk.byteLength === SKLEN)
-  assert(pk.byteLength === PKLEN)
+function dh (publicKey, { scalar, secretKey }) {
+  // tweaked keys expose scalar directly
+  if (!scalar) {
+    assert(secretKey.byteLength === SKLEN)
+
+    // libsodium stores seed not actual scalar
+    const sk = b4a.alloc(64)
+    sodium.crypto_hash_sha512(sk, secretKey.subarray(0, 32))
+    sk[0] &= 248
+    sk[31] &= 127
+    sk[31] |= 64
+
+    scalar = sk.subarray(0, 32)
+  }
+
+  assert(scalar.byteLength === SCALARLEN)
+  assert(publicKey.byteLength === PKLEN)
 
   const output = b4a.alloc(DHLEN)
 
-  // libsodium stores seed not actual scalar
-  const sk = b4a.alloc(64)
-  sodium.crypto_hash_sha512(sk, lsk.subarray(0, 32))
-  sk[0] &= 248
-  sk[31] &= 127
-  sk[31] |= 64
-
-  sodium.crypto_scalarmult_ed25519(
+  // we clamp if necessary above
+  sodium.crypto_scalarmult_ed25519_noclamp(
     output,
-    sk.subarray(0, 32),
-    pk
+    scalar,
+    publicKey
   )
 
   return output

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "hypercore-crypto-tweak": "github:holepunchto/hypercore-crypto-tweak",
-    "noise-handshake": "^1.1.0",
+    "noise-handshake": "^3.0.0",
     "standard": "^16.0.3",
     "tape": "^5.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sodium-universal": "^3.0.4"
   },
   "devDependencies": {
+    "hypercore-crypto-tweak": "github:holepunchto/hypercore-crypto-tweak",
     "noise-handshake": "^1.1.0",
     "standard": "^16.0.3",
     "tape": "^5.2.2"


### PR DESCRIPTION
Tweaked ed25519 key pairs pass `scalar` directly, so in this PR, we only derive `scalar` if it has not already been passed.

These changes require noise-handshake v3.0.0, since the `dh` function signature has changed.